### PR TITLE
Added new optimized versions.

### DIFF
--- a/concat_benchmark.py
+++ b/concat_benchmark.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import libmyrustlib
 
 iterations = 1000
@@ -28,3 +30,15 @@ def test_concat_comprehensions(benchmark):
 
 def test_concat_rust(benchmark):
     benchmark(libmyrustlib.rust_concat, iterations)
+
+def test_concat_rust_reserve(benchmark):
+    benchmark(libmyrustlib.rust_concat_reserve, iterations)
+
+def test_concat_rust_logdigits(benchmark):
+    benchmark(libmyrustlib.rust_concat_logdigits, iterations)
+
+def test_concat_rust_buffer(benchmark):
+    benchmark(libmyrustlib.rust_concat_buffer, iterations)
+
+def test_concat_rust_inplace(benchmark):
+    benchmark(libmyrustlib.rust_concat_inplace, iterations)

--- a/pyext-myrustlib/src/lib.rs
+++ b/pyext-myrustlib/src/lib.rs
@@ -1,10 +1,15 @@
 #[macro_use] extern crate cpython;
 
+use std::fmt::Write;
 use cpython::{PyResult, Python};
 
 py_module_initializer!(libmyrustlib, initlibmyrustlib, PyInit_libmyrustlib, |py, m| {
     m.add(py, "__doc__", "This module is implemented in Rust.")?;
     m.add(py, "rust_concat", py_fn!(py, rust_concat(val: i64)))?;
+    m.add(py, "rust_concat_reserve", py_fn!(py, rust_concat_reserve(val: i64)))?;
+    m.add(py, "rust_concat_logdigits", py_fn!(py, rust_concat_logdigits(val: i64)))?;
+    m.add(py, "rust_concat_buffer", py_fn!(py, rust_concat_buffer(val: i64)))?;
+    m.add(py, "rust_concat_inplace", py_fn!(py, rust_concat_inplace(val: i64)))?;
     Ok(())
 });
 
@@ -12,6 +17,71 @@ fn rust_concat(_: Python, val: i64) -> PyResult<String> {
     let mut result = String::new();
     for i in 0..val {
         result.push_str(&i.to_string());
+    }
+    Ok(result)
+}
+
+fn rust_concat_reserve(_: Python, val: i64) -> PyResult<String> {
+    let mut digits = 0usize;
+    let mut order = 1usize;
+    for i in 0usize..(val as usize) {
+        if i == order * 10 {
+            order *= 10
+        }
+        digits += order;
+    }
+
+    let mut result = String::with_capacity(digits);
+    for i in 0usize..(val as usize) {
+        result.push_str(&i.to_string());
+    }
+    Ok(result)
+}
+
+fn range_digits(val: i64) -> usize {
+    assert!(val >= 0);
+    if val == 0 {
+        return 0;
+    }
+    let val = val as usize;
+    let mut digits = 1usize;
+    let mut base = 1usize;
+    let mut digits_sum = 1usize; // For 0.
+    while 10usize * base < val {
+        digits_sum += 9usize * digits * base;
+        digits += 1usize;
+        base *= 10usize;
+    }
+    digits_sum += (val - base) * digits;
+    digits_sum
+}
+
+fn rust_concat_logdigits(_: Python, val: i64) -> PyResult<String> {
+    let digits = range_digits(val);
+    let mut result = String::with_capacity(digits);
+    for i in 0usize..(val as usize) {
+        result.push_str(&i.to_string());
+    }
+    Ok(result)
+}
+
+fn rust_concat_buffer(_: Python, val: i64) -> PyResult<String> {
+    let digits = range_digits(val);
+    let mut result = String::with_capacity(digits);
+    let mut tmp = val.to_string();
+    for i in 0usize..(val as usize) {
+        tmp.clear();
+        write!(&mut tmp, "{}", i).unwrap();
+        result.push_str(&tmp);
+    }
+    Ok(result)
+}
+
+fn rust_concat_inplace(_: Python, val: i64) -> PyResult<String> {
+    let digits = range_digits(val);
+    let mut result = String::with_capacity(digits);
+    for i in 0usize..(val as usize) {
+        write!(&mut result, "{}", i).unwrap();
     }
     Ok(result)
 }


### PR DESCRIPTION
- Compute the size of the output buffer and reserve it in advance.
- Make the prior computation logarithmic.
- Use a single temporary buffer for formatted numbers.
- Directly format to the output buffer.

Lookup table was ultimately discarded, since tests showed this computation was far from being the bottleneck.

Here are my numbers:
```
------------------------------------------------------------------------------------------- benchmark: 8 tests ------------------------------------------------------------------------------------------
Name (time in us)                   Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_concat_rust_inplace        18.5140 (1.0)      120.7690 (1.0)       20.3017 (1.0)       5.3681 (1.0)       19.1130 (1.0)       0.0780 (1.28)   2966;12393       49.2568 (1.0)       48036           1
test_concat_rust_buffer         21.9180 (1.18)     312.4010 (2.59)      23.9116 (1.18)      6.3351 (1.18)      22.5950 (1.18)      0.0610 (1.0)     2039;7604       41.8208 (0.85)      39854           1
test_concat_rust_logdigits      34.4170 (1.86)     171.9880 (1.42)      38.2211 (1.88)      8.9614 (1.67)      36.0520 (1.89)      0.2580 (4.23)    2099;6621       26.1635 (0.53)      26157           1
test_concat_rust_reserve        35.3610 (1.91)     332.0350 (2.75)      38.7706 (1.91)      8.3582 (1.56)      36.7935 (1.93)      0.1060 (1.74)    1511;3854       25.7927 (0.52)      21766           1
test_concat_rust                35.3690 (1.91)     123.9050 (1.03)      38.1021 (1.88)      8.0472 (1.50)      36.2830 (1.90)      0.5490 (9.00)      777;906       26.2453 (0.53)      12816           1
test_concat_comprehensions     110.6790 (5.98)     398.8780 (3.30)     121.8844 (6.00)     23.9349 (4.46)     111.3870 (5.83)     13.9218 (228.23)    632;628        8.2045 (0.17)       8461           1
test_concat_join               132.5880 (7.16)     338.9440 (2.81)     145.3816 (7.16)     26.4589 (4.93)     133.3960 (6.98)     14.4695 (237.21)    431;459        6.8785 (0.14)       5652           1
test_concat_basic              148.6820 (8.03)     369.6140 (3.06)     157.7084 (7.77)     25.8755 (4.82)     149.2470 (7.81)      3.7380 (61.28)     399;716        6.3408 (0.13)       5086           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```